### PR TITLE
Handle category API envelope

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,12 @@ Copus is a browser extension that helps authors save the current webpage to the 
 2. Use the **Load unpacked** button and select this repository directory.
 3. Open any webpage and launch the Copus extension popup from the toolbar to test the workflow.
 
+### Version management
+
+Run the helper script below before committing changes so the manifest version advances and future merges avoid conflicts:
+
+```
+node scripts/bumpVersion.js
+```
+
 The publish action currently logs the prepared payload and can be replaced with the official Copus API integration when it becomes available.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# Copus_Browser_Extension
+# Copus Browser Extension
+
+Copus is a browser extension that helps authors save the current webpage to the Copus platform with all required publishing metadata.
+
+## Features
+
+- Automatically inspects the current page to collect title, URL, and images.
+- Suggests a cover image while allowing manual upload, screenshot capture, or choosing any detected page image.
+- Loads article categories from the Copus API and requires users to pick one before publishing.
+- Collects a sharing recommendation to accompany the saved page.
+- Validates every required field before allowing publication.
+
+## Development
+
+1. Load the extension in your Chromium-based browser via **chrome://extensions** in developer mode.
+2. Use the **Load unpacked** button and select this repository directory.
+3. Open any webpage and launch the Copus extension popup from the toolbar to test the workflow.
+
+The publish action currently logs the prepared payload and can be replaced with the official Copus API integration when it becomes available.

--- a/background.js
+++ b/background.js
@@ -1,0 +1,18 @@
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'captureScreenshot') {
+    const targetWindowId = message.windowId;
+
+    chrome.tabs.captureVisibleTab(targetWindowId, { format: 'png' }, (dataUrl) => {
+      if (chrome.runtime.lastError) {
+        sendResponse({ success: false, error: chrome.runtime.lastError.message });
+        return;
+      }
+
+      sendResponse({ success: true, dataUrl });
+    });
+
+    return true;
+  }
+
+  return undefined;
+});

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,0 +1,60 @@
+function getAbsoluteUrl(url) {
+  try {
+    return new URL(url, window.location.href).href;
+  } catch (error) {
+    return url;
+  }
+}
+
+function collectPageImages() {
+  const rawImages = Array.from(document.images || []);
+  const uniqueSources = new Set();
+  const images = [];
+
+  rawImages.forEach((image) => {
+    if (!image || !image.src) {
+      return;
+    }
+
+    const absoluteSrc = getAbsoluteUrl(image.src);
+
+    if (!absoluteSrc || uniqueSources.has(absoluteSrc)) {
+      return;
+    }
+
+    uniqueSources.add(absoluteSrc);
+    images.push({
+      src: absoluteSrc,
+      width: image.naturalWidth || image.width || 0,
+      height: image.naturalHeight || image.height || 0
+    });
+  });
+
+  const ogImage = document.querySelector("meta[property='og:image']");
+  if (ogImage && ogImage.content) {
+    const ogSrc = getAbsoluteUrl(ogImage.content);
+
+    if (!uniqueSources.has(ogSrc)) {
+      images.unshift({
+        src: ogSrc,
+        width: 0,
+        height: 0
+      });
+      uniqueSources.add(ogSrc);
+    }
+  }
+
+  return images;
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'collectPageData') {
+    const images = collectPageImages();
+
+    sendResponse({
+      title: document.title,
+      url: window.location.href,
+      images
+    });
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Copus",
   "description": "Save and publish webpages to Copus with cover image and categorization tools.",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "permissions": [
     "activeTab",
     "tabs",

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,33 @@
+{
+  "manifest_version": 3,
+  "name": "Copus",
+  "description": "Save and publish webpages to Copus with cover image and categorization tools.",
+  "version": "0.1.1",
+  "permissions": [
+    "activeTab",
+    "tabs",
+    "scripting",
+    "tabCapture"
+  ],
+  "host_permissions": [
+    "https://api.test.copus.io/*",
+    "<all_urls>"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "contentScript.js"
+      ],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Copus",
   "description": "Save and publish webpages to Copus with cover image and categorization tools.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "permissions": [
     "activeTab",
     "tabs",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Copus",
   "description": "Save and publish webpages to Copus with cover image and categorization tools.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "permissions": [
     "activeTab",
     "tabs",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Copus",
   "description": "Save and publish webpages to Copus with cover image and categorization tools.",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "permissions": [
     "activeTab",
     "tabs",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Copus",
   "description": "Save and publish webpages to Copus with cover image and categorization tools.",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "permissions": [
     "activeTab",
     "tabs",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Copus",
   "description": "Save and publish webpages to Copus with cover image and categorization tools.",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "permissions": [
     "activeTab",
     "tabs",

--- a/popup.css
+++ b/popup.css
@@ -1,0 +1,207 @@
+:root {
+  color-scheme: light dark;
+  --color-background: #ffffff;
+  --color-text: #1f2933;
+  --color-muted: #52606d;
+  --color-border: #d9e2ec;
+  --color-primary: #2d7ff9;
+  --color-primary-text: #ffffff;
+  --color-error: #d64545;
+  font-size: 16px;
+}
+
+body {
+  width: 420px;
+  margin: 0;
+  padding: 0;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  background: var(--color-background);
+  color: var(--color-text);
+}
+
+.popup {
+  padding: 16px;
+}
+
+.popup__header {
+  margin-bottom: 12px;
+}
+
+.popup__title {
+  font-size: 1.5rem;
+  margin: 0 0 4px;
+}
+
+.popup__subtitle {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.popup__section {
+  margin-bottom: 16px;
+}
+
+.popup__section--page-info .page-info {
+  margin: 4px 0;
+  font-size: 0.9rem;
+}
+
+.label {
+  font-weight: 600;
+  margin-right: 4px;
+}
+
+.section__title {
+  font-size: 1rem;
+  margin: 0 0 8px;
+}
+
+.required {
+  color: var(--color-error);
+  margin-left: 4px;
+}
+
+.cover-container {
+  position: relative;
+  width: 100%;
+  height: 180px;
+  border: 2px dashed var(--color-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f8fafc;
+  overflow: hidden;
+  border-radius: 8px;
+}
+
+.cover-placeholder {
+  text-align: center;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+  padding: 0 12px;
+}
+
+.cover-preview {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.cover-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--color-border);
+  background: #f0f4f8;
+  color: var(--color-text);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.button:hover {
+  background: #e3ebf6;
+}
+
+.button--primary {
+  background: var(--color-primary);
+  color: var(--color-primary-text);
+  border-color: var(--color-primary);
+}
+
+.button--primary:hover {
+  background: #1a68d1;
+}
+
+.button--file {
+  position: relative;
+}
+
+.image-selection {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(72px, 1fr));
+  gap: 8px;
+  margin-top: 12px;
+  max-height: 160px;
+  overflow-y: auto;
+}
+
+.image-selection__empty {
+  grid-column: 1 / -1;
+  text-align: center;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.image-option {
+  position: relative;
+  border: 2px solid transparent;
+  border-radius: 8px;
+  overflow: hidden;
+  cursor: pointer;
+  padding: 0;
+  background: none;
+}
+
+.image-option--selected {
+  border-color: var(--color-primary);
+}
+
+.image-option img {
+  width: 100%;
+  height: 72px;
+  object-fit: cover;
+  display: block;
+}
+
+.input {
+  width: 100%;
+  padding: 8px;
+  border-radius: 6px;
+  border: 1px solid var(--color-border);
+  font-size: 0.95rem;
+  box-sizing: border-box;
+}
+
+.input:focus {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 1px;
+}
+
+.input--textarea {
+  resize: vertical;
+  min-height: 100px;
+}
+
+.status-message {
+  min-height: 20px;
+  font-size: 0.9rem;
+  margin-top: 8px;
+}
+
+.status-message--error {
+  color: var(--color-error);
+}
+
+.status-message--success {
+  color: #1f9d55;
+}
+
+.popup__section--actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/popup.css
+++ b/popup.css
@@ -23,21 +23,6 @@ body {
   padding: 16px;
 }
 
-.popup__header {
-  margin-bottom: 12px;
-}
-
-.popup__title {
-  font-size: 1.5rem;
-  margin: 0 0 4px;
-}
-
-.popup__subtitle {
-  margin: 0;
-  color: var(--color-muted);
-  font-size: 0.9rem;
-}
-
 .popup__section {
   margin-bottom: 16px;
 }
@@ -73,6 +58,8 @@ body {
   background: #f8fafc;
   overflow: hidden;
   border-radius: 8px;
+  padding: 16px;
+  box-sizing: border-box;
 }
 
 .cover-placeholder {
@@ -82,16 +69,51 @@ body {
   padding: 0 12px;
 }
 
+.cover-placeholder p {
+  margin: 4px 0;
+}
+
 .cover-preview {
   width: 100%;
   height: 100%;
   object-fit: cover;
 }
 
-.cover-actions {
-  display: flex;
+.cover-container--filled {
+  border-style: solid;
+  padding: 0;
+}
+
+.cover-controls {
+  display: grid;
   gap: 8px;
-  margin-top: 8px;
+  margin-top: 12px;
+}
+
+.cover-controls .button {
+  width: 100%;
+}
+
+.cover-remove {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(0, 0, 0, 0.55);
+  color: #ffffff;
+  font-size: 1.2rem;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cover-remove:hover {
+  background: rgba(0, 0, 0, 0.7);
 }
 
 .button {
@@ -110,6 +132,12 @@ body {
 
 .button:hover {
   background: #e3ebf6;
+}
+
+.button:disabled,
+.button[aria-disabled='true'] {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .button--primary {
@@ -133,6 +161,10 @@ body {
   margin-top: 12px;
   max-height: 160px;
   overflow-y: auto;
+}
+
+.image-selection--hidden {
+  display: none;
 }
 
 .image-selection__empty {
@@ -199,9 +231,4 @@ body {
 .popup__section--actions {
   display: flex;
   justify-content: flex-end;
-}
-
-.button[disabled] {
-  opacity: 0.6;
-  cursor: not-allowed;
 }

--- a/popup.html
+++ b/popup.html
@@ -8,11 +8,6 @@
   </head>
   <body>
     <main class="popup">
-      <header class="popup__header">
-        <h1 class="popup__title">Publish to Copus</h1>
-        <p class="popup__subtitle">Save the current page and share it with your readers.</p>
-      </header>
-
       <section class="popup__section popup__section--page-info">
         <h2 class="section__title">Page details</h2>
         <p class="page-info"><span class="label">Title:</span> <span id="page-title">Loading...</span></p>
@@ -22,18 +17,28 @@
       <section class="popup__section popup__section--cover">
         <h2 class="section__title">Cover image<span class="required">*</span></h2>
         <div id="cover-container" class="cover-container">
+          <img id="cover-preview" class="cover-preview" alt="Selected cover preview" hidden />
+          <button
+            id="cover-remove"
+            class="cover-remove"
+            type="button"
+            aria-label="Remove cover image"
+            hidden
+          >
+            &times;
+          </button>
           <div id="cover-placeholder" class="cover-placeholder">
             <p>No cover image selected.</p>
             <p>Please upload or capture an image to continue.</p>
+            <div id="cover-controls" class="cover-controls">
+              <label class="button button--file" for="cover-upload">Upload from device</label>
+              <input id="cover-upload" type="file" accept="image/*" hidden />
+              <button id="cover-screenshot" class="button" type="button">Capture screenshot</button>
+              <button id="cover-detected-toggle" class="button" type="button">Choose from detected images</button>
+            </div>
           </div>
-          <img id="cover-preview" class="cover-preview" alt="Selected cover preview" hidden />
         </div>
-        <div class="cover-actions">
-          <label class="button button--file" for="cover-upload">Upload from device</label>
-          <input id="cover-upload" type="file" accept="image/*" hidden />
-          <button id="cover-screenshot" class="button" type="button">Capture screenshot</button>
-        </div>
-        <div id="image-selection" class="image-selection"></div>
+        <div id="image-selection" class="image-selection image-selection--hidden" hidden></div>
       </section>
 
       <section class="popup__section">
@@ -45,7 +50,13 @@
 
       <section class="popup__section">
         <h2 class="section__title">Recommendation reason<span class="required">*</span></h2>
-        <textarea id="recommendation-input" class="input input--textarea" rows="4" placeholder="Share why this page matters." required></textarea>
+        <textarea
+          id="recommendation-input"
+          class="input input--textarea"
+          rows="4"
+          placeholder="Share why this page matters."
+          required
+        ></textarea>
       </section>
 
       <section class="popup__section popup__section--actions">

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Copus Publisher</title>
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
+    <main class="popup">
+      <header class="popup__header">
+        <h1 class="popup__title">Publish to Copus</h1>
+        <p class="popup__subtitle">Save the current page and share it with your readers.</p>
+      </header>
+
+      <section class="popup__section popup__section--page-info">
+        <h2 class="section__title">Page details</h2>
+        <p class="page-info"><span class="label">Title:</span> <span id="page-title">Loading...</span></p>
+        <p class="page-info"><span class="label">URL:</span> <span id="page-url">Loading...</span></p>
+      </section>
+
+      <section class="popup__section popup__section--cover">
+        <h2 class="section__title">Cover image<span class="required">*</span></h2>
+        <div id="cover-container" class="cover-container">
+          <div id="cover-placeholder" class="cover-placeholder">
+            <p>No cover image selected.</p>
+            <p>Please upload or capture an image to continue.</p>
+          </div>
+          <img id="cover-preview" class="cover-preview" alt="Selected cover preview" hidden />
+        </div>
+        <div class="cover-actions">
+          <label class="button button--file" for="cover-upload">Upload from device</label>
+          <input id="cover-upload" type="file" accept="image/*" hidden />
+          <button id="cover-screenshot" class="button" type="button">Capture screenshot</button>
+        </div>
+        <div id="image-selection" class="image-selection"></div>
+      </section>
+
+      <section class="popup__section">
+        <h2 class="section__title">Category<span class="required">*</span></h2>
+        <select id="category-select" class="input" required>
+          <option value="" disabled selected>Select a category</option>
+        </select>
+      </section>
+
+      <section class="popup__section">
+        <h2 class="section__title">Recommendation reason<span class="required">*</span></h2>
+        <textarea id="recommendation-input" class="input input--textarea" rows="4" placeholder="Share why this page matters." required></textarea>
+      </section>
+
+      <section class="popup__section popup__section--actions">
+        <button id="publish-button" class="button button--primary" type="button">Publish to Copus</button>
+      </section>
+
+      <p id="status-message" class="status-message" role="alert"></p>
+    </main>
+
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -133,15 +133,27 @@ async function fetchPageData(tabId) {
 }
 
 function extractCategoriesFromResponse(rawResponse) {
+  if (!rawResponse) {
+    return null;
+  }
+
   if (Array.isArray(rawResponse)) {
     return rawResponse;
   }
 
-  if (rawResponse && Array.isArray(rawResponse.data)) {
-    return rawResponse.data;
+  if (Array.isArray(rawResponse.categoryList)) {
+    return rawResponse.categoryList;
   }
 
-  if (rawResponse && rawResponse.data) {
+  if (rawResponse.data) {
+    if (Array.isArray(rawResponse.data)) {
+      return rawResponse.data;
+    }
+
+    if (Array.isArray(rawResponse.data.categoryList)) {
+      return rawResponse.data.categoryList;
+    }
+
     if (Array.isArray(rawResponse.data.list)) {
       return rawResponse.data.list;
     }
@@ -151,12 +163,14 @@ function extractCategoriesFromResponse(rawResponse) {
     }
   }
 
-  if (rawResponse && Array.isArray(rawResponse.result)) {
-    return rawResponse.result;
-  }
+  if (rawResponse.result) {
+    if (Array.isArray(rawResponse.result)) {
+      return rawResponse.result;
+    }
 
-  if (rawResponse && rawResponse.result && Array.isArray(rawResponse.result.list)) {
-    return rawResponse.result.list;
+    if (Array.isArray(rawResponse.result.list)) {
+      return rawResponse.result.list;
+    }
   }
 
   return null;
@@ -194,22 +208,37 @@ function populateCategorySelect(categories) {
   placeholderOption.selected = true;
   elements.categorySelect.appendChild(placeholderOption);
 
+  let optionsAdded = 0;
+
   categories.forEach((category) => {
-    const option = document.createElement('option');
-    option.value =
+    const categoryId =
+      category.categoryId ||
       category.id ||
       category.value ||
-      category.categoryId ||
       category.code ||
       '';
-    option.textContent =
+
+    const categoryName =
+      category.categoryName ||
       category.name ||
       category.label ||
-      category.categoryName ||
       category.title ||
       'Unnamed category';
+
+    if (!categoryId || !categoryName) {
+      return;
+    }
+
+    const option = document.createElement('option');
+    option.value = categoryId;
+    option.textContent = categoryName;
     elements.categorySelect.appendChild(option);
+    optionsAdded += 1;
   });
+
+  if (optionsAdded === 0) {
+    setStatus('No categories available from Copus. Please try again later.', 'error');
+  }
 }
 
 function validateForm() {

--- a/popup.js
+++ b/popup.js
@@ -58,6 +58,9 @@ function setCoverImage(coverImage, sourceType) {
     elements.coverPlaceholder.hidden = true;
     elements.coverRemoveButton.hidden = false;
     elements.coverContainer.classList.add('cover-container--filled');
+    if (elements.coverControls) {
+      elements.coverControls.hidden = true;
+    }
   } else {
     elements.coverPreview.hidden = true;
     elements.coverPlaceholder.hidden = false;

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,377 @@
+const state = {
+  coverImage: null,
+  coverSourceType: null,
+  images: [],
+  activeTabId: null,
+  activeWindowId: null
+};
+
+const elements = {};
+
+function cacheElements() {
+  elements.pageTitle = document.getElementById('page-title');
+  elements.pageUrl = document.getElementById('page-url');
+  elements.coverPlaceholder = document.getElementById('cover-placeholder');
+  elements.coverPreview = document.getElementById('cover-preview');
+  elements.coverUpload = document.getElementById('cover-upload');
+  elements.coverScreenshot = document.getElementById('cover-screenshot');
+  elements.imageSelection = document.getElementById('image-selection');
+  elements.categorySelect = document.getElementById('category-select');
+  elements.recommendationInput = document.getElementById('recommendation-input');
+  elements.publishButton = document.getElementById('publish-button');
+  elements.statusMessage = document.getElementById('status-message');
+}
+
+function setStatus(message, type = 'info') {
+  elements.statusMessage.textContent = message;
+  elements.statusMessage.classList.remove('status-message--error', 'status-message--success');
+
+  if (type === 'error') {
+    elements.statusMessage.classList.add('status-message--error');
+  }
+
+  if (type === 'success') {
+    elements.statusMessage.classList.add('status-message--success');
+  }
+}
+
+function setCoverImage(coverImage, sourceType) {
+  state.coverImage = coverImage;
+  state.coverSourceType = sourceType;
+
+  if (coverImage && coverImage.src) {
+    elements.coverPreview.src = coverImage.src;
+    elements.coverPreview.hidden = false;
+    elements.coverPlaceholder.hidden = true;
+  } else {
+    elements.coverPreview.hidden = true;
+    elements.coverPlaceholder.hidden = false;
+  }
+
+  updateImageSelectionHighlight();
+}
+
+function updateImageSelectionHighlight() {
+  const options = elements.imageSelection.querySelectorAll('.image-option');
+  options.forEach((option) => {
+    const imageSrc = option.dataset.src;
+    if (state.coverImage && state.coverImage.src === imageSrc && state.coverSourceType === 'page') {
+      option.classList.add('image-option--selected');
+    } else {
+      option.classList.remove('image-option--selected');
+    }
+  });
+}
+
+function determineMainImage(images) {
+  if (!Array.isArray(images) || images.length === 0) {
+    return null;
+  }
+
+  const sorted = [...images].sort((a, b) => {
+    const areaA = (a.width || 0) * (a.height || 0);
+    const areaB = (b.width || 0) * (b.height || 0);
+    return areaB - areaA;
+  });
+
+  return sorted[0] || null;
+}
+
+function renderImageSelection(images) {
+  elements.imageSelection.innerHTML = '';
+
+  if (!Array.isArray(images) || images.length === 0) {
+    const emptyState = document.createElement('p');
+    emptyState.textContent = 'No images detected on this page.';
+    emptyState.className = 'image-selection__empty';
+    elements.imageSelection.appendChild(emptyState);
+    return;
+  }
+
+  images.forEach((image) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'image-option';
+    button.dataset.src = image.src;
+
+    const thumbnail = document.createElement('img');
+    thumbnail.src = image.src;
+    thumbnail.alt = 'Available cover option';
+
+    button.appendChild(thumbnail);
+
+    button.addEventListener('click', () => {
+      setCoverImage({ src: image.src }, 'page');
+      setStatus('Cover image updated from the page images.');
+    });
+
+    elements.imageSelection.appendChild(button);
+  });
+
+  updateImageSelectionHighlight();
+}
+
+async function queryActiveTab() {
+  return new Promise((resolve) => {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      resolve(tabs[0]);
+    });
+  });
+}
+
+async function fetchPageData(tabId) {
+  return new Promise((resolve, reject) => {
+    chrome.tabs.sendMessage(tabId, { type: 'collectPageData' }, (response) => {
+      if (chrome.runtime.lastError) {
+        reject(new Error(chrome.runtime.lastError.message));
+        return;
+      }
+
+      resolve(response);
+    });
+  });
+}
+
+function extractCategoriesFromResponse(rawResponse) {
+  if (Array.isArray(rawResponse)) {
+    return rawResponse;
+  }
+
+  if (rawResponse && Array.isArray(rawResponse.data)) {
+    return rawResponse.data;
+  }
+
+  if (rawResponse && rawResponse.data) {
+    if (Array.isArray(rawResponse.data.list)) {
+      return rawResponse.data.list;
+    }
+
+    if (Array.isArray(rawResponse.data.items)) {
+      return rawResponse.data.items;
+    }
+  }
+
+  if (rawResponse && Array.isArray(rawResponse.result)) {
+    return rawResponse.result;
+  }
+
+  if (rawResponse && rawResponse.result && Array.isArray(rawResponse.result.list)) {
+    return rawResponse.result.list;
+  }
+
+  return null;
+}
+
+async function fetchCategories() {
+  try {
+    const response = await fetch('https://api.test.copus.io/plugin/plugin/author/article/categoryList');
+
+    if (!response.ok) {
+      throw new Error(`Failed to load categories (${response.status})`);
+    }
+
+    const data = await response.json();
+    const categories = extractCategoriesFromResponse(data);
+
+    if (!Array.isArray(categories)) {
+      throw new Error('Unexpected category response format.');
+    }
+
+    populateCategorySelect(categories);
+  } catch (error) {
+    console.error('Category fetch failed', error);
+    setStatus(`Unable to load categories: ${error.message}`, 'error');
+  }
+}
+
+function populateCategorySelect(categories) {
+  elements.categorySelect.innerHTML = '';
+
+  const placeholderOption = document.createElement('option');
+  placeholderOption.value = '';
+  placeholderOption.textContent = 'Select a category';
+  placeholderOption.disabled = true;
+  placeholderOption.selected = true;
+  elements.categorySelect.appendChild(placeholderOption);
+
+  categories.forEach((category) => {
+    const option = document.createElement('option');
+    option.value =
+      category.id ||
+      category.value ||
+      category.categoryId ||
+      category.code ||
+      '';
+    option.textContent =
+      category.name ||
+      category.label ||
+      category.categoryName ||
+      category.title ||
+      'Unnamed category';
+    elements.categorySelect.appendChild(option);
+  });
+}
+
+function validateForm() {
+  if (!state.coverImage || !state.coverImage.src) {
+    setStatus('Please select, upload, or capture a cover image before publishing.', 'error');
+    return false;
+  }
+
+  if (!elements.categorySelect.value) {
+    setStatus('Please choose a category.', 'error');
+    return false;
+  }
+
+  if (!elements.recommendationInput.value.trim()) {
+    setStatus('Please provide a recommendation reason.', 'error');
+    return false;
+  }
+
+  return true;
+}
+
+async function publishToCopus(payload) {
+  // Placeholder for future API integration.
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  console.info('Publishing payload prepared for Copus:', payload);
+  return { success: true };
+}
+
+async function handlePublish() {
+  if (!validateForm()) {
+    return;
+  }
+
+  const payload = {
+    title: elements.pageTitle.textContent,
+    url: elements.pageUrl.textContent,
+    coverImage: state.coverImage.src,
+    coverImageSource: state.coverSourceType,
+    category: elements.categorySelect.value,
+    recommendation: elements.recommendationInput.value.trim()
+  };
+
+  try {
+    elements.publishButton.disabled = true;
+    setStatus('Publishing to Copus...');
+
+    const result = await publishToCopus(payload);
+
+    if (result.success) {
+      setStatus('The page has been queued for publishing to Copus.', 'success');
+    } else {
+      throw new Error(result.message || 'Publishing failed.');
+    }
+  } catch (error) {
+    setStatus(`Unable to publish: ${error.message}`, 'error');
+  } finally {
+    elements.publishButton.disabled = false;
+  }
+}
+
+function handleFileUpload(event) {
+  const file = event.target.files && event.target.files[0];
+
+  if (!file) {
+    return;
+  }
+
+  const reader = new FileReader();
+  reader.onload = () => {
+    setCoverImage({ src: reader.result }, 'upload');
+    setStatus('Cover image updated from your upload.');
+  };
+  reader.onerror = () => {
+    setStatus('Failed to read the selected file. Please try again.', 'error');
+  };
+  reader.readAsDataURL(file);
+}
+
+async function handleScreenshotCapture() {
+  try {
+    elements.coverScreenshot.disabled = true;
+    setStatus('Capturing screenshot...');
+
+    const tab = await queryActiveTab();
+
+    if (!tab) {
+      throw new Error('No active tab available for capture.');
+    }
+
+    const screenshot = await new Promise((resolve, reject) => {
+      chrome.runtime.sendMessage(
+        { type: 'captureScreenshot', windowId: tab.windowId },
+        (response) => {
+          if (chrome.runtime.lastError) {
+            reject(new Error(chrome.runtime.lastError.message));
+            return;
+          }
+
+          if (!response || !response.success) {
+            reject(new Error(response && response.error ? response.error : 'Screenshot failed.'));
+            return;
+          }
+
+          resolve(response.dataUrl);
+        }
+      );
+    });
+
+    setCoverImage({ src: screenshot }, 'screenshot');
+    setStatus('Cover image updated from the screenshot.');
+  } catch (error) {
+    setStatus(`Unable to capture screenshot: ${error.message}`, 'error');
+  } finally {
+    elements.coverScreenshot.disabled = false;
+  }
+}
+
+async function initialize() {
+  cacheElements();
+  setStatus('Initializing...');
+
+  const tab = await queryActiveTab();
+  if (!tab) {
+    setStatus('Unable to determine the active tab.', 'error');
+    return;
+  }
+
+  state.activeTabId = tab.id;
+  state.activeWindowId = tab.windowId;
+  elements.pageTitle.textContent = tab.title || 'Untitled page';
+  elements.pageUrl.textContent = tab.url || 'Unknown URL';
+
+  try {
+    const pageData = await fetchPageData(tab.id);
+
+    if (pageData && Array.isArray(pageData.images)) {
+      state.images = pageData.images;
+      renderImageSelection(pageData.images);
+      const mainImage = determineMainImage(pageData.images);
+      if (mainImage && mainImage.src) {
+        setCoverImage({ src: mainImage.src }, 'page');
+        setStatus('A cover image was automatically selected.');
+      } else {
+        setCoverImage(null, null);
+        setStatus('No main image detected. Please choose or upload a cover.', 'error');
+      }
+    } else {
+      setCoverImage(null, null);
+      renderImageSelection([]);
+      setStatus('No images detected on this page. Please upload or capture a cover image.', 'error');
+    }
+  } catch (error) {
+    setCoverImage(null, null);
+    renderImageSelection([]);
+    setStatus(`Unable to inspect the page: ${error.message}`, 'error');
+  }
+
+  fetchCategories();
+
+  elements.coverUpload.addEventListener('change', handleFileUpload);
+  elements.coverScreenshot.addEventListener('click', handleScreenshotCapture);
+  elements.publishButton.addEventListener('click', handlePublish);
+}
+
+document.addEventListener('DOMContentLoaded', initialize);

--- a/scripts/bumpVersion.js
+++ b/scripts/bumpVersion.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+
+const manifestPath = path.join(__dirname, '..', 'manifest.json');
+
+function readManifest() {
+  const raw = fs.readFileSync(manifestPath, 'utf8');
+  return JSON.parse(raw);
+}
+
+function writeManifest(manifest) {
+  const formatted = `${JSON.stringify(manifest, null, 2)}\n`;
+  fs.writeFileSync(manifestPath, formatted, 'utf8');
+}
+
+function bumpPatch(version) {
+  const segments = version.split('.').map((segment) => Number.parseInt(segment, 10));
+
+  while (segments.length < 3) {
+    segments.push(0);
+  }
+
+  if (segments.some((segment) => Number.isNaN(segment) || segment < 0)) {
+    throw new Error(`Invalid semantic version provided: ${version}`);
+  }
+
+  segments[2] += 1;
+  return segments.join('.');
+}
+
+function main() {
+  const manifest = readManifest();
+  const currentVersion = manifest.version;
+
+  if (!currentVersion) {
+    throw new Error('Manifest file does not contain a version field.');
+  }
+
+  const nextVersion = bumpPatch(currentVersion);
+  manifest.version = nextVersion;
+  writeManifest(manifest);
+
+  console.log(`Bumped manifest version from ${currentVersion} to ${nextVersion}.`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- make the category loader tolerant of wrapped API responses and additional field names
- log category fetch errors for easier debugging while still surfacing feedback in the UI
- bump the extension manifest to version 0.1.1

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d029e5479c8331aa1f15945af4e232