### PR TITLE
Refine cover image controls in popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,12 @@ node scripts/bumpVersion.js
 > **Note:** Run the script immediately before committing your work so every pull request carries a unique version pair.
 > This keeps GitHub from flagging manifest conflicts when multiple updates are in flight.
 
+You can double-check that no merge markers accidentally remain in the repository by running the conflict scanner:
+
+```
+node scripts/checkForConflicts.js
+```
+
+The command exits with a non-zero status if it finds any `<<<<<<<`, `=======`, or `>>>>>>>` markers so they can be cleaned up before opening a pull request.
+
 The publish action currently logs the prepared payload and can be replaced with the official Copus API integration when it becomes available.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# Copus_Browser_Extension
+# Copus Browser Extension
+
+Copus is a browser extension that helps authors save the current webpage to the Copus platform with all required publishing metadata.
+
+## Features
+
+- Automatically inspects the current page to collect title, URL, and images.
+- Suggests a cover image while allowing manual upload, screenshot capture, or choosing any detected page image.
+- Loads article categories from the Copus API and requires users to pick one before publishing.
+- Collects a sharing recommendation to accompany the saved page.
+- Validates every required field before allowing publication.
+
+## Development
+
+1. Load the extension in your Chromium-based browser via **chrome://extensions** in developer mode.
+2. Use the **Load unpacked** button and select this repository directory.
+3. Open any webpage and launch the Copus extension popup from the toolbar to test the workflow.
+
+### Version management
+
+Run the helper script below before committing changes so the manifest version advances and future merges avoid conflicts:
+
+```
+node scripts/bumpVersion.js
+```
+
+The publish action currently logs the prepared payload and can be replaced with the official Copus API integration when it becomes available.

--- a/README.md
+++ b/README.md
@@ -18,10 +18,13 @@ Copus is a browser extension that helps authors save the current webpage to the 
 
 ### Version management
 
-Run the helper script below before committing changes so the manifest version advances and future merges avoid conflicts:
+Run the helper script below before committing changes so the manifest version and manifest version name advance and future merges avoid conflicts:
 
 ```
 node scripts/bumpVersion.js
 ```
+
+> **Note:** Run the script immediately before committing your work so every pull request carries a unique version pair.
+> This keeps GitHub from flagging manifest conflicts when multiple updates are in flight.
 
 The publish action currently logs the prepared payload and can be replaced with the official Copus API integration when it becomes available.

--- a/background.js
+++ b/background.js
@@ -1,0 +1,18 @@
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'captureScreenshot') {
+    const targetWindowId = message.windowId;
+
+    chrome.tabs.captureVisibleTab(targetWindowId, { format: 'png' }, (dataUrl) => {
+      if (chrome.runtime.lastError) {
+        sendResponse({ success: false, error: chrome.runtime.lastError.message });
+        return;
+      }
+
+      sendResponse({ success: true, dataUrl });
+    });
+
+    return true;
+  }
+
+  return undefined;
+});

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,0 +1,60 @@
+function getAbsoluteUrl(url) {
+  try {
+    return new URL(url, window.location.href).href;
+  } catch (error) {
+    return url;
+  }
+}
+
+function collectPageImages() {
+  const rawImages = Array.from(document.images || []);
+  const uniqueSources = new Set();
+  const images = [];
+
+  rawImages.forEach((image) => {
+    if (!image || !image.src) {
+      return;
+    }
+
+    const absoluteSrc = getAbsoluteUrl(image.src);
+
+    if (!absoluteSrc || uniqueSources.has(absoluteSrc)) {
+      return;
+    }
+
+    uniqueSources.add(absoluteSrc);
+    images.push({
+      src: absoluteSrc,
+      width: image.naturalWidth || image.width || 0,
+      height: image.naturalHeight || image.height || 0
+    });
+  });
+
+  const ogImage = document.querySelector("meta[property='og:image']");
+  if (ogImage && ogImage.content) {
+    const ogSrc = getAbsoluteUrl(ogImage.content);
+
+    if (!uniqueSources.has(ogSrc)) {
+      images.unshift({
+        src: ogSrc,
+        width: 0,
+        height: 0
+      });
+      uniqueSources.add(ogSrc);
+    }
+  }
+
+  return images;
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'collectPageData') {
+    const images = collectPageImages();
+
+    sendResponse({
+      title: document.title,
+      url: window.location.href,
+      images
+    });
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 3,
   "name": "Copus",
   "description": "Save and publish webpages to Copus with cover image and categorization tools.",
-  "version": "0.1.8",
-  "version_name": "0.1.8",
+  "version": "0.1.9",
+  "version_name": "0.1.9",
   "permissions": [
     "activeTab",
     "tabs",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,8 @@
   "manifest_version": 3,
   "name": "Copus",
   "description": "Save and publish webpages to Copus with cover image and categorization tools.",
-  "version": "0.1.7",
+  "version": "0.1.8",
+  "version_name": "0.1.8",
   "permissions": [
     "activeTab",
     "tabs",

--- a/manifest.json
+++ b/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 3,
   "name": "Copus",
   "description": "Save and publish webpages to Copus with cover image and categorization tools.",
-  "version": "0.1.9",
-  "version_name": "0.1.9",
+  "version": "0.1.10",
+  "version_name": "0.1.10",
   "permissions": [
     "activeTab",
     "tabs",

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,33 @@
+{
+  "manifest_version": 3,
+  "name": "Copus",
+  "description": "Save and publish webpages to Copus with cover image and categorization tools.",
+  "version": "0.1.7",
+  "permissions": [
+    "activeTab",
+    "tabs",
+    "scripting",
+    "tabCapture"
+  ],
+  "host_permissions": [
+    "https://api.test.copus.io/*",
+    "<all_urls>"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "contentScript.js"
+      ],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/popup.css
+++ b/popup.css
@@ -1,0 +1,234 @@
+:root {
+  color-scheme: light dark;
+  --color-background: #ffffff;
+  --color-text: #1f2933;
+  --color-muted: #52606d;
+  --color-border: #d9e2ec;
+  --color-primary: #2d7ff9;
+  --color-primary-text: #ffffff;
+  --color-error: #d64545;
+  font-size: 16px;
+}
+
+body {
+  width: 420px;
+  margin: 0;
+  padding: 0;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  background: var(--color-background);
+  color: var(--color-text);
+}
+
+.popup {
+  padding: 16px;
+}
+
+.popup__section {
+  margin-bottom: 16px;
+}
+
+.popup__section--page-info .page-info {
+  margin: 4px 0;
+  font-size: 0.9rem;
+}
+
+.label {
+  font-weight: 600;
+  margin-right: 4px;
+}
+
+.section__title {
+  font-size: 1rem;
+  margin: 0 0 8px;
+}
+
+.required {
+  color: var(--color-error);
+  margin-left: 4px;
+}
+
+.cover-container {
+  position: relative;
+  width: 100%;
+  height: 180px;
+  border: 2px dashed var(--color-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f8fafc;
+  overflow: hidden;
+  border-radius: 8px;
+  padding: 16px;
+  box-sizing: border-box;
+}
+
+.cover-placeholder {
+  text-align: center;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+  padding: 0 12px;
+}
+
+.cover-placeholder p {
+  margin: 4px 0;
+}
+
+.cover-preview {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.cover-container--filled {
+  border-style: solid;
+  padding: 0;
+}
+
+.cover-controls {
+  display: grid;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.cover-controls .button {
+  width: 100%;
+}
+
+.cover-remove {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(0, 0, 0, 0.55);
+  color: #ffffff;
+  font-size: 1.2rem;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cover-remove:hover {
+  background: rgba(0, 0, 0, 0.7);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--color-border);
+  background: #f0f4f8;
+  color: var(--color-text);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.button:hover {
+  background: #e3ebf6;
+}
+
+.button:disabled,
+.button[aria-disabled='true'] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.button--primary {
+  background: var(--color-primary);
+  color: var(--color-primary-text);
+  border-color: var(--color-primary);
+}
+
+.button--primary:hover {
+  background: #1a68d1;
+}
+
+.button--file {
+  position: relative;
+}
+
+.image-selection {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(72px, 1fr));
+  gap: 8px;
+  margin-top: 12px;
+  max-height: 160px;
+  overflow-y: auto;
+}
+
+.image-selection--hidden {
+  display: none;
+}
+
+.image-selection__empty {
+  grid-column: 1 / -1;
+  text-align: center;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.image-option {
+  position: relative;
+  border: 2px solid transparent;
+  border-radius: 8px;
+  overflow: hidden;
+  cursor: pointer;
+  padding: 0;
+  background: none;
+}
+
+.image-option--selected {
+  border-color: var(--color-primary);
+}
+
+.image-option img {
+  width: 100%;
+  height: 72px;
+  object-fit: cover;
+  display: block;
+}
+
+.input {
+  width: 100%;
+  padding: 8px;
+  border-radius: 6px;
+  border: 1px solid var(--color-border);
+  font-size: 0.95rem;
+  box-sizing: border-box;
+}
+
+.input:focus {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 1px;
+}
+
+.input--textarea {
+  resize: vertical;
+  min-height: 100px;
+}
+
+.status-message {
+  min-height: 20px;
+  font-size: 0.9rem;
+  margin-top: 8px;
+}
+
+.status-message--error {
+  color: var(--color-error);
+}
+
+.status-message--success {
+  color: #1f9d55;
+}
+
+.popup__section--actions {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Copus Publisher</title>
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
+    <main class="popup">
+      <section class="popup__section popup__section--page-info">
+        <h2 class="section__title">Page details</h2>
+        <p class="page-info"><span class="label">Title:</span> <span id="page-title">Loading...</span></p>
+        <p class="page-info"><span class="label">URL:</span> <span id="page-url">Loading...</span></p>
+      </section>
+
+      <section class="popup__section popup__section--cover">
+        <h2 class="section__title">Cover image<span class="required">*</span></h2>
+        <div id="cover-container" class="cover-container">
+          <img id="cover-preview" class="cover-preview" alt="Selected cover preview" hidden />
+          <button
+            id="cover-remove"
+            class="cover-remove"
+            type="button"
+            aria-label="Remove cover image"
+            hidden
+          >
+            &times;
+          </button>
+          <div id="cover-placeholder" class="cover-placeholder">
+            <p>No cover image selected.</p>
+            <p>Please upload or capture an image to continue.</p>
+            <div id="cover-controls" class="cover-controls">
+              <label class="button button--file" for="cover-upload">Upload from device</label>
+              <input id="cover-upload" type="file" accept="image/*" hidden />
+              <button id="cover-screenshot" class="button" type="button">Capture screenshot</button>
+              <button id="cover-detected-toggle" class="button" type="button">Choose from detected images</button>
+            </div>
+          </div>
+        </div>
+        <div id="image-selection" class="image-selection image-selection--hidden" hidden></div>
+      </section>
+
+      <section class="popup__section">
+        <h2 class="section__title">Category<span class="required">*</span></h2>
+        <select id="category-select" class="input" required>
+          <option value="" disabled selected>Select a category</option>
+        </select>
+      </section>
+
+      <section class="popup__section">
+        <h2 class="section__title">Recommendation reason<span class="required">*</span></h2>
+        <textarea
+          id="recommendation-input"
+          class="input input--textarea"
+          rows="4"
+          placeholder="Share why this page matters."
+          required
+        ></textarea>
+      </section>
+
+      <section class="popup__section popup__section--actions">
+        <button id="publish-button" class="button button--primary" type="button">Publish to Copus</button>
+      </section>
+
+      <p id="status-message" class="status-message" role="alert"></p>
+    </main>
+
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,589 @@
+const state = {
+  coverImage: null,
+  coverSourceType: null,
+  images: [],
+  activeTabId: null,
+  activeWindowId: null,
+  imageSelectionVisible: false
+};
+
+const elements = {};
+
+function cacheElements() {
+  elements.coverContainer = document.getElementById('cover-container');
+  elements.pageTitle = document.getElementById('page-title');
+  elements.pageUrl = document.getElementById('page-url');
+  elements.coverPlaceholder = document.getElementById('cover-placeholder');
+  elements.coverPreview = document.getElementById('cover-preview');
+  elements.coverUpload = document.getElementById('cover-upload');
+  elements.coverScreenshot = document.getElementById('cover-screenshot');
+  elements.coverControls = document.getElementById('cover-controls');
+  elements.coverDetectedToggle = document.getElementById('cover-detected-toggle');
+  elements.coverRemoveButton = document.getElementById('cover-remove');
+  elements.imageSelection = document.getElementById('image-selection');
+  elements.categorySelect = document.getElementById('category-select');
+  elements.recommendationInput = document.getElementById('recommendation-input');
+  elements.publishButton = document.getElementById('publish-button');
+  elements.statusMessage = document.getElementById('status-message');
+
+  if (elements.coverDetectedToggle) {
+    elements.coverDetectedToggle.disabled = true;
+    elements.coverDetectedToggle.setAttribute('aria-disabled', 'true');
+    elements.coverDetectedToggle.setAttribute('aria-expanded', 'false');
+  }
+
+  setImageSelectionVisibility(false);
+}
+
+function setStatus(message, type = 'info') {
+  elements.statusMessage.textContent = message;
+  elements.statusMessage.classList.remove('status-message--error', 'status-message--success');
+
+  if (type === 'error') {
+    elements.statusMessage.classList.add('status-message--error');
+  }
+
+  if (type === 'success') {
+    elements.statusMessage.classList.add('status-message--success');
+  }
+}
+
+function setCoverImage(coverImage, sourceType) {
+  state.coverImage = coverImage;
+  state.coverSourceType = sourceType;
+
+  if (coverImage && coverImage.src) {
+    elements.coverPreview.src = coverImage.src;
+    elements.coverPreview.hidden = false;
+    elements.coverPlaceholder.hidden = true;
+    elements.coverRemoveButton.hidden = false;
+    elements.coverContainer.classList.add('cover-container--filled');
+    if (elements.coverControls) {
+      elements.coverControls.hidden = true;
+    }
+  } else {
+    elements.coverPreview.hidden = true;
+    elements.coverPlaceholder.hidden = false;
+    elements.coverRemoveButton.hidden = true;
+    elements.coverContainer.classList.remove('cover-container--filled');
+    if (elements.coverControls) {
+      elements.coverControls.hidden = false;
+    }
+    if (elements.coverUpload) {
+      elements.coverUpload.value = '';
+    }
+  }
+
+  updateImageSelectionHighlight();
+}
+
+function setImageSelectionVisibility(visible) {
+  state.imageSelectionVisible = visible;
+
+  if (!elements.imageSelection) {
+    return;
+  }
+
+  if (visible) {
+    elements.imageSelection.hidden = false;
+    elements.imageSelection.classList.remove('image-selection--hidden');
+  } else {
+    elements.imageSelection.hidden = true;
+    elements.imageSelection.classList.add('image-selection--hidden');
+  }
+
+  if (elements.coverDetectedToggle) {
+    elements.coverDetectedToggle.textContent = visible ? 'Hide detected images' : 'Choose from detected images';
+    elements.coverDetectedToggle.setAttribute('aria-expanded', String(visible));
+  }
+}
+
+function updateImageSelectionHighlight() {
+  const options = elements.imageSelection.querySelectorAll('.image-option');
+  options.forEach((option) => {
+    const imageSrc = option.dataset.src;
+    if (state.coverImage && state.coverImage.src === imageSrc && state.coverSourceType === 'page') {
+      option.classList.add('image-option--selected');
+    } else {
+      option.classList.remove('image-option--selected');
+    }
+  });
+}
+
+function determineMainImage(images) {
+  if (!Array.isArray(images) || images.length === 0) {
+    return null;
+  }
+
+  const sorted = [...images].sort((a, b) => {
+    const areaA = (a.width || 0) * (a.height || 0);
+    const areaB = (b.width || 0) * (b.height || 0);
+    return areaB - areaA;
+  });
+
+  return sorted[0] || null;
+}
+
+function renderImageSelection(images) {
+  elements.imageSelection.innerHTML = '';
+
+  if (!Array.isArray(images) || images.length === 0) {
+    const emptyState = document.createElement('p');
+    emptyState.textContent = 'No images detected on this page.';
+    emptyState.className = 'image-selection__empty';
+    elements.imageSelection.appendChild(emptyState);
+    if (elements.coverDetectedToggle) {
+      elements.coverDetectedToggle.disabled = true;
+      elements.coverDetectedToggle.textContent = 'No detected images found';
+      elements.coverDetectedToggle.setAttribute('aria-disabled', 'true');
+    }
+    setImageSelectionVisibility(false);
+    return;
+  }
+
+  if (elements.coverDetectedToggle) {
+    elements.coverDetectedToggle.disabled = false;
+    elements.coverDetectedToggle.removeAttribute('aria-disabled');
+    elements.coverDetectedToggle.textContent = 'Choose from detected images';
+  }
+
+  images.forEach((image) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'image-option';
+    button.dataset.src = image.src;
+
+    const thumbnail = document.createElement('img');
+    thumbnail.src = image.src;
+    thumbnail.alt = 'Available cover option';
+
+    button.appendChild(thumbnail);
+
+    button.addEventListener('click', () => {
+      setCoverImage({ src: image.src }, 'page');
+      setStatus('Cover image updated from the page images.');
+      setImageSelectionVisibility(false);
+    });
+
+    elements.imageSelection.appendChild(button);
+  });
+
+  updateImageSelectionHighlight();
+  setImageSelectionVisibility(state.imageSelectionVisible && images.length > 0);
+}
+
+async function queryActiveTab() {
+  return new Promise((resolve) => {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      resolve(tabs[0]);
+    });
+  });
+}
+
+async function fetchPageData(tabId) {
+  return new Promise((resolve, reject) => {
+    chrome.tabs.sendMessage(tabId, { type: 'collectPageData' }, (response) => {
+      if (chrome.runtime.lastError) {
+        reject(new Error(chrome.runtime.lastError.message));
+        return;
+      }
+
+      resolve(response);
+    });
+  });
+}
+
+function tryParseJson(value) {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return value;
+  }
+
+  const isJsonContainer =
+    (trimmed.startsWith('{') && trimmed.endsWith('}')) || (trimmed.startsWith('[') && trimmed.endsWith(']'));
+
+  if (!isJsonContainer) {
+    return value;
+  }
+
+  try {
+    return JSON.parse(trimmed);
+  } catch (error) {
+    console.warn('Unable to parse JSON from category payload.', error);
+    return value;
+  }
+}
+
+function normalizeCategoryEntry(rawValue) {
+  if (!rawValue || typeof rawValue !== 'object') {
+    return null;
+  }
+
+  const idCandidate =
+    rawValue.categoryId ??
+    rawValue.categoryID ??
+    rawValue.category_id ??
+    rawValue.category_code ??
+    rawValue.categoryCode ??
+    rawValue.id ??
+    rawValue.value ??
+    rawValue.code;
+
+  const nameCandidate =
+    rawValue.categoryName ??
+    rawValue.category_name ??
+    rawValue.categoryTitle ??
+    rawValue.category_title ??
+    rawValue.name ??
+    rawValue.label ??
+    rawValue.title;
+
+  if (idCandidate === undefined || idCandidate === null) {
+    return null;
+  }
+
+  if (nameCandidate === undefined || nameCandidate === null) {
+    return null;
+  }
+
+  const categoryId = String(idCandidate).trim();
+  const categoryName = String(nameCandidate).trim();
+
+  if (!categoryId || !categoryName) {
+    return null;
+  }
+
+  return { id: categoryId, name: categoryName };
+}
+
+function collectCategories(candidate, bucket, visited) {
+  if (candidate === null || candidate === undefined) {
+    return;
+  }
+
+  const parsedCandidate = tryParseJson(candidate);
+
+  if (typeof parsedCandidate === 'object') {
+    if (visited.has(parsedCandidate)) {
+      return;
+    }
+
+    visited.add(parsedCandidate);
+  }
+
+  if (Array.isArray(parsedCandidate)) {
+    parsedCandidate.forEach((entry) => {
+      collectCategories(entry, bucket, visited);
+    });
+    return;
+  }
+
+  if (typeof parsedCandidate !== 'object') {
+    return;
+  }
+
+  const normalized = normalizeCategoryEntry(parsedCandidate);
+  if (normalized) {
+    bucket.push(normalized);
+  }
+
+  const childKeys = ['children', 'categoryList', 'list', 'items', 'rows', 'records'];
+
+  childKeys.forEach((key) => {
+    if (Object.prototype.hasOwnProperty.call(parsedCandidate, key)) {
+      collectCategories(parsedCandidate[key], bucket, visited);
+    }
+  });
+
+  Object.values(parsedCandidate).forEach((value) => {
+    collectCategories(value, bucket, visited);
+  });
+}
+
+function resolveCategoriesFromPayload(payload) {
+  const entryPoints = [];
+
+  if (payload && typeof payload === 'object') {
+    if (Array.isArray(payload)) {
+      entryPoints.push(payload);
+    } else {
+      const containerKeys = ['data', 'result', 'payload', 'response'];
+      const categoryRoot = containerKeys.reduce((acc, key) => {
+        if (acc !== undefined) {
+          return acc;
+        }
+
+        if (Object.prototype.hasOwnProperty.call(payload, key)) {
+          return payload[key];
+        }
+
+        return undefined;
+      }, undefined);
+
+      if (categoryRoot !== undefined) {
+        entryPoints.push(categoryRoot);
+      }
+
+      if (Object.prototype.hasOwnProperty.call(payload, 'categoryList')) {
+        entryPoints.push(payload.categoryList);
+      }
+    }
+  }
+
+  if (entryPoints.length === 0) {
+    entryPoints.push(payload);
+  }
+
+  const collected = [];
+  const visited = new Set();
+
+  entryPoints.forEach((entry) => {
+    collectCategories(entry, collected, visited);
+  });
+
+  const unique = new Map();
+  collected.forEach((category) => {
+    if (!unique.has(category.id)) {
+      unique.set(category.id, category);
+    }
+  });
+
+  return Array.from(unique.values());
+}
+
+async function fetchCategories() {
+  try {
+    const response = await fetch('https://api.test.copus.io/plugin/plugin/author/article/categoryList');
+
+    if (!response.ok) {
+      throw new Error(`Failed to load categories (${response.status})`);
+    }
+
+    const data = await response.json();
+    const categories = resolveCategoriesFromPayload(data);
+
+    if (!Array.isArray(categories) || categories.length === 0) {
+      throw new Error('No categories returned from Copus.');
+    }
+
+    populateCategorySelect(categories);
+  } catch (error) {
+    console.error('Category fetch failed', error);
+    setStatus(`Unable to load categories: ${error.message}`, 'error');
+  }
+}
+
+function populateCategorySelect(categories) {
+  elements.categorySelect.innerHTML = '';
+
+  const placeholderOption = document.createElement('option');
+  placeholderOption.value = '';
+  placeholderOption.textContent = 'Select a category';
+  placeholderOption.disabled = true;
+  placeholderOption.selected = true;
+  elements.categorySelect.appendChild(placeholderOption);
+
+  let optionsAdded = 0;
+
+  categories.forEach((category) => {
+    if (!category || !category.id || !category.name) {
+      return;
+    }
+
+    const option = document.createElement('option');
+    option.value = category.id;
+    option.textContent = category.name;
+    elements.categorySelect.appendChild(option);
+    optionsAdded += 1;
+  });
+
+  if (optionsAdded === 0) {
+    setStatus('No categories available from Copus. Please try again later.', 'error');
+  }
+}
+
+function validateForm() {
+  if (!state.coverImage || !state.coverImage.src) {
+    setStatus('Please select, upload, or capture a cover image before publishing.', 'error');
+    return false;
+  }
+
+  if (!elements.categorySelect.value) {
+    setStatus('Please choose a category.', 'error');
+    return false;
+  }
+
+  if (!elements.recommendationInput.value.trim()) {
+    setStatus('Please provide a recommendation reason.', 'error');
+    return false;
+  }
+
+  return true;
+}
+
+async function publishToCopus(payload) {
+  // Placeholder for future API integration.
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  console.info('Publishing payload prepared for Copus:', payload);
+  return { success: true };
+}
+
+async function handlePublish() {
+  if (!validateForm()) {
+    return;
+  }
+
+  const payload = {
+    title: elements.pageTitle.textContent,
+    url: elements.pageUrl.textContent,
+    coverImage: state.coverImage.src,
+    coverImageSource: state.coverSourceType,
+    category: elements.categorySelect.value,
+    recommendation: elements.recommendationInput.value.trim()
+  };
+
+  try {
+    elements.publishButton.disabled = true;
+    setStatus('Publishing to Copus...');
+
+    const result = await publishToCopus(payload);
+
+    if (result.success) {
+      setStatus('The page has been queued for publishing to Copus.', 'success');
+    } else {
+      throw new Error(result.message || 'Publishing failed.');
+    }
+  } catch (error) {
+    setStatus(`Unable to publish: ${error.message}`, 'error');
+  } finally {
+    elements.publishButton.disabled = false;
+  }
+}
+
+function handleFileUpload(event) {
+  const file = event.target.files && event.target.files[0];
+
+  if (!file) {
+    return;
+  }
+
+  const reader = new FileReader();
+  reader.onload = () => {
+    setCoverImage({ src: reader.result }, 'upload');
+    setStatus('Cover image updated from your upload.');
+    if (elements.coverUpload) {
+      elements.coverUpload.value = '';
+    }
+  };
+  reader.onerror = () => {
+    setStatus('Failed to read the selected file. Please try again.', 'error');
+  };
+  reader.readAsDataURL(file);
+}
+
+async function handleScreenshotCapture() {
+  try {
+    elements.coverScreenshot.disabled = true;
+    setStatus('Capturing screenshot...');
+
+    const tab = await queryActiveTab();
+
+    if (!tab) {
+      throw new Error('No active tab available for capture.');
+    }
+
+    const screenshot = await new Promise((resolve, reject) => {
+      chrome.runtime.sendMessage(
+        { type: 'captureScreenshot', windowId: tab.windowId },
+        (response) => {
+          if (chrome.runtime.lastError) {
+            reject(new Error(chrome.runtime.lastError.message));
+            return;
+          }
+
+          if (!response || !response.success) {
+            reject(new Error(response && response.error ? response.error : 'Screenshot failed.'));
+            return;
+          }
+
+          resolve(response.dataUrl);
+        }
+      );
+    });
+
+    setCoverImage({ src: screenshot }, 'screenshot');
+    setStatus('Cover image updated from the screenshot.');
+  } catch (error) {
+    setStatus(`Unable to capture screenshot: ${error.message}`, 'error');
+  } finally {
+    elements.coverScreenshot.disabled = false;
+  }
+}
+
+function handleCoverRemoval() {
+  setCoverImage(null, null);
+  setStatus('Cover image removed. Please choose or upload a new cover.', 'error');
+}
+
+function handleDetectedToggle() {
+  if (!state.images || state.images.length === 0) {
+    return;
+  }
+
+  setImageSelectionVisibility(!state.imageSelectionVisible);
+}
+
+async function initialize() {
+  cacheElements();
+  setStatus('Initializing...');
+
+  const tab = await queryActiveTab();
+  if (!tab) {
+    setStatus('Unable to determine the active tab.', 'error');
+    return;
+  }
+
+  state.activeTabId = tab.id;
+  state.activeWindowId = tab.windowId;
+  elements.pageTitle.textContent = tab.title || 'Untitled page';
+  elements.pageUrl.textContent = tab.url || 'Unknown URL';
+
+  try {
+    const pageData = await fetchPageData(tab.id);
+
+    if (pageData && Array.isArray(pageData.images)) {
+      state.images = pageData.images;
+      renderImageSelection(pageData.images);
+      const mainImage = determineMainImage(pageData.images);
+      if (mainImage && mainImage.src) {
+        setCoverImage({ src: mainImage.src }, 'page');
+        setStatus('A cover image was automatically selected.');
+      } else {
+        setCoverImage(null, null);
+        setStatus('No main image detected. Please choose or upload a cover.', 'error');
+      }
+    } else {
+      setCoverImage(null, null);
+      renderImageSelection([]);
+      setStatus('No images detected on this page. Please upload or capture a cover image.', 'error');
+    }
+  } catch (error) {
+    setCoverImage(null, null);
+    renderImageSelection([]);
+    setStatus(`Unable to inspect the page: ${error.message}`, 'error');
+  }
+
+  fetchCategories();
+
+  elements.coverUpload.addEventListener('change', handleFileUpload);
+  elements.coverScreenshot.addEventListener('click', handleScreenshotCapture);
+  elements.coverRemoveButton.addEventListener('click', handleCoverRemoval);
+  elements.coverDetectedToggle.addEventListener('click', handleDetectedToggle);
+  elements.publishButton.addEventListener('click', handlePublish);
+}
+
+document.addEventListener('DOMContentLoaded', initialize);

--- a/scripts/bumpVersion.js
+++ b/scripts/bumpVersion.js
@@ -38,6 +38,7 @@ function main() {
 
   const nextVersion = bumpPatch(currentVersion);
   manifest.version = nextVersion;
+  manifest.version_name = nextVersion;
   writeManifest(manifest);
 
   console.log(`Bumped manifest version from ${currentVersion} to ${nextVersion}.`);

--- a/scripts/bumpVersion.js
+++ b/scripts/bumpVersion.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+
+const manifestPath = path.join(__dirname, '..', 'manifest.json');
+
+function readManifest() {
+  const raw = fs.readFileSync(manifestPath, 'utf8');
+  return JSON.parse(raw);
+}
+
+function writeManifest(manifest) {
+  const formatted = `${JSON.stringify(manifest, null, 2)}\n`;
+  fs.writeFileSync(manifestPath, formatted, 'utf8');
+}
+
+function bumpPatch(version) {
+  const segments = version.split('.').map((segment) => Number.parseInt(segment, 10));
+
+  while (segments.length < 3) {
+    segments.push(0);
+  }
+
+  if (segments.some((segment) => Number.isNaN(segment) || segment < 0)) {
+    throw new Error(`Invalid semantic version provided: ${version}`);
+  }
+
+  segments[2] += 1;
+  return segments.join('.');
+}
+
+function main() {
+  const manifest = readManifest();
+  const currentVersion = manifest.version;
+
+  if (!currentVersion) {
+    throw new Error('Manifest file does not contain a version field.');
+  }
+
+  const nextVersion = bumpPatch(currentVersion);
+  manifest.version = nextVersion;
+  writeManifest(manifest);
+
+  console.log(`Bumped manifest version from ${currentVersion} to ${nextVersion}.`);
+}
+
+main();

--- a/scripts/checkForConflicts.js
+++ b/scripts/checkForConflicts.js
@@ -1,0 +1,45 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function listTrackedFiles() {
+  const output = execSync('git ls-files', { encoding: 'utf8' });
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+function fileContainsConflictMarkers(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const conflictPattern = /^(<{7}|={7}|>{7})\s/m;
+  return conflictPattern.test(content);
+}
+
+function main() {
+  const repoRoot = path.resolve(__dirname, '..');
+  const files = listTrackedFiles();
+  const conflictedFiles = [];
+
+  files.forEach((relativeFile) => {
+    const absoluteFile = path.join(repoRoot, relativeFile);
+    if (!fs.existsSync(absoluteFile) || fs.statSync(absoluteFile).isDirectory()) {
+      return;
+    }
+
+    if (fileContainsConflictMarkers(absoluteFile)) {
+      conflictedFiles.push(relativeFile);
+    }
+  });
+
+  if (conflictedFiles.length > 0) {
+    console.error('Conflict markers detected in the following files:');
+    conflictedFiles.forEach((file) => console.error(` - ${file}`));
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log('No conflict markers detected.');
+}
+
+main();


### PR DESCRIPTION
## Summary
- remove the marketing header text and relocate cover controls inside the placeholder frame so they only show when no cover is set
- add a dismiss control and toggled detected-image panel to manage covers, keeping detected assets behind an explicit action
- disable detected-image selection until data loads, hide the cover controls when a cover exists, and bump the manifest version to 0.1.7
- align the category parsing with the Copus `categoryList` envelope so normalized entries reliably populate the dropdown
- add a version bump helper script and document its use so manifest versions advance cleanly on every change

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d029e5479c8331aa1f15945af4e232