### PR TITLE
Update popup cover image interactions

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -23,21 +23,6 @@ body {
   padding: 16px;
 }
 
-.popup__header {
-  margin-bottom: 12px;
-}
-
-.popup__title {
-  font-size: 1.5rem;
-  margin: 0 0 4px;
-}
-
-.popup__subtitle {
-  margin: 0;
-  color: var(--color-muted);
-  font-size: 0.9rem;
-}
-
 .popup__section {
   margin-bottom: 16px;
 }
@@ -67,31 +52,54 @@ body {
   width: 100%;
   height: 180px;
   border: 2px dashed var(--color-border);
+  border-radius: 8px;
+  background: #f8fafc;
+  overflow: hidden;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #f8fafc;
-  overflow: hidden;
-  border-radius: 8px;
+  padding: 16px;
+  box-sizing: border-box;
 }
 
-.cover-placeholder {
+.cover-container--has-image {
+  border: none;
+  padding: 0;
+}
+
+.cover-empty {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: center;
+  justify-content: center;
   text-align: center;
   color: var(--color-muted);
   font-size: 0.9rem;
+  z-index: 1;
+  width: 100%;
+  height: 100%;
+}
+
+.cover-placeholder {
   padding: 0 12px;
 }
 
-.cover-preview {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+.cover-placeholder p {
+  margin: 4px 0;
 }
 
 .cover-actions {
   display: flex;
+  flex-direction: column;
   gap: 8px;
-  margin-top: 8px;
+  width: 100%;
+  max-width: 240px;
+}
+
+.cover-actions .button,
+.cover-actions .button--file {
+  width: 100%;
 }
 
 .button {
@@ -112,6 +120,16 @@ body {
   background: #e3ebf6;
 }
 
+.button--ghost {
+  background: transparent;
+  border-color: transparent;
+  color: var(--color-primary);
+}
+
+.button--ghost:hover {
+  background: rgba(45, 127, 249, 0.12);
+}
+
 .button--primary {
   background: var(--color-primary);
   color: var(--color-primary-text);
@@ -124,6 +142,49 @@ body {
 
 .button--file {
   position: relative;
+}
+
+.cover-preview {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  z-index: 0;
+}
+
+.cover-remove {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(17, 24, 39, 0.72);
+  color: #ffffff;
+  font-size: 1.2rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 2;
+}
+
+.cover-remove:hover {
+  background: rgba(17, 24, 39, 0.9);
+}
+
+.cover-remove:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.image-tools {
+  margin-top: 8px;
+  display: flex;
+  justify-content: flex-end;
 }
 
 .image-selection {

--- a/popup.html
+++ b/popup.html
@@ -8,10 +8,6 @@
   </head>
   <body>
     <main class="popup">
-      <header class="popup__header">
-        <h1 class="popup__title">Publish to Copus</h1>
-        <p class="popup__subtitle">Save the current page and share it with your readers.</p>
-      </header>
 
       <section class="popup__section popup__section--page-info">
         <h2 class="section__title">Page details</h2>
@@ -22,18 +18,41 @@
       <section class="popup__section popup__section--cover">
         <h2 class="section__title">Cover image<span class="required">*</span></h2>
         <div id="cover-container" class="cover-container">
-          <div id="cover-placeholder" class="cover-placeholder">
-            <p>No cover image selected.</p>
-            <p>Please upload or capture an image to continue.</p>
+          <div id="cover-empty" class="cover-empty">
+            <div id="cover-placeholder" class="cover-placeholder">
+              <p>No cover image selected.</p>
+              <p>Please choose, upload, or capture an image to continue.</p>
+            </div>
+            <div id="cover-actions" class="cover-actions">
+              <label class="button button--file" for="cover-upload">Upload from device</label>
+              <input id="cover-upload" type="file" accept="image/*" hidden />
+              <button id="cover-screenshot" class="button" type="button">Capture screenshot</button>
+            </div>
           </div>
           <img id="cover-preview" class="cover-preview" alt="Selected cover preview" hidden />
+          <button
+            id="cover-remove"
+            class="cover-remove"
+            type="button"
+            aria-label="Remove cover image"
+            title="Remove cover image"
+            hidden
+          >
+            <span aria-hidden="true">&times;</span>
+          </button>
         </div>
-        <div class="cover-actions">
-          <label class="button button--file" for="cover-upload">Upload from device</label>
-          <input id="cover-upload" type="file" accept="image/*" hidden />
-          <button id="cover-screenshot" class="button" type="button">Capture screenshot</button>
+        <div class="image-tools">
+          <button
+            id="toggle-detected-images"
+            class="button button--ghost"
+            type="button"
+            aria-expanded="false"
+            aria-controls="image-selection"
+          >
+            Show detected images
+          </button>
         </div>
-        <div id="image-selection" class="image-selection"></div>
+        <div id="image-selection" class="image-selection" hidden></div>
       </section>
 
       <section class="popup__section">


### PR DESCRIPTION
## Summary
- remove the popup header copy and tuck image actions inside the cover frame
- show cover management buttons only when no image is loaded and add a remove control
- gate detected page images behind a toggle button so the list stays hidden until requested

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d122afedb48331b7554489339acd91