### PR TITLE
Refine cover image empty state handling

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -23,21 +23,6 @@ body {
   padding: 16px;
 }
 
-.popup__header {
-  margin-bottom: 12px;
-}
-
-.popup__title {
-  font-size: 1.5rem;
-  margin: 0 0 4px;
-}
-
-.popup__subtitle {
-  margin: 0;
-  color: var(--color-muted);
-  font-size: 0.9rem;
-}
-
 .popup__section {
   margin-bottom: 16px;
 }
@@ -67,31 +52,62 @@ body {
   width: 100%;
   height: 180px;
   border: 2px dashed var(--color-border);
+  border-radius: 8px;
+  background: #f8fafc;
+  overflow: hidden;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #f8fafc;
-  overflow: hidden;
-  border-radius: 8px;
+  padding: 16px;
+  box-sizing: border-box;
 }
 
-.cover-placeholder {
+.cover-container--has-image {
+  border: none;
+  padding: 0;
+}
+
+.cover-container--has-image .cover-empty {
+  display: none;
+}
+
+.cover-container--empty .cover-remove {
+  display: none;
+}
+
+.cover-empty {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: center;
+  justify-content: center;
   text-align: center;
   color: var(--color-muted);
   font-size: 0.9rem;
+  z-index: 1;
+  width: 100%;
+  height: 100%;
+}
+
+.cover-placeholder {
   padding: 0 12px;
 }
 
-.cover-preview {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+.cover-placeholder p {
+  margin: 4px 0;
 }
 
 .cover-actions {
   display: flex;
+  flex-direction: column;
   gap: 8px;
-  margin-top: 8px;
+  width: 100%;
+  max-width: 240px;
+}
+
+.cover-actions .button,
+.cover-actions .button--file {
+  width: 100%;
 }
 
 .button {
@@ -112,6 +128,16 @@ body {
   background: #e3ebf6;
 }
 
+.button--ghost {
+  background: transparent;
+  border-color: transparent;
+  color: var(--color-primary);
+}
+
+.button--ghost:hover {
+  background: rgba(45, 127, 249, 0.12);
+}
+
 .button--primary {
   background: var(--color-primary);
   color: var(--color-primary-text);
@@ -124,6 +150,49 @@ body {
 
 .button--file {
   position: relative;
+}
+
+.cover-preview {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  z-index: 0;
+}
+
+.cover-remove {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(17, 24, 39, 0.72);
+  color: #ffffff;
+  font-size: 1.2rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 2;
+}
+
+.cover-remove:hover {
+  background: rgba(17, 24, 39, 0.9);
+}
+
+.cover-remove:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.image-tools {
+  margin-top: 8px;
+  display: flex;
+  justify-content: flex-end;
 }
 
 .image-selection {

--- a/popup.html
+++ b/popup.html
@@ -8,10 +8,6 @@
   </head>
   <body>
     <main class="popup">
-      <header class="popup__header">
-        <h1 class="popup__title">Publish to Copus</h1>
-        <p class="popup__subtitle">Save the current page and share it with your readers.</p>
-      </header>
 
       <section class="popup__section popup__section--page-info">
         <h2 class="section__title">Page details</h2>
@@ -21,19 +17,42 @@
 
       <section class="popup__section popup__section--cover">
         <h2 class="section__title">Cover image<span class="required">*</span></h2>
-        <div id="cover-container" class="cover-container">
-          <div id="cover-placeholder" class="cover-placeholder">
-            <p>No cover image selected.</p>
-            <p>Please upload or capture an image to continue.</p>
+        <div id="cover-container" class="cover-container cover-container--empty">
+          <div id="cover-empty" class="cover-empty">
+            <div id="cover-placeholder" class="cover-placeholder">
+              <p>No cover image selected.</p>
+              <p>Please choose, upload, or capture an image to continue.</p>
+            </div>
+            <div id="cover-actions" class="cover-actions">
+              <label class="button button--file" for="cover-upload">Upload from device</label>
+              <input id="cover-upload" type="file" accept="image/*" hidden />
+              <button id="cover-screenshot" class="button" type="button">Capture screenshot</button>
+            </div>
           </div>
           <img id="cover-preview" class="cover-preview" alt="Selected cover preview" hidden />
+          <button
+            id="cover-remove"
+            class="cover-remove"
+            type="button"
+            aria-label="Remove cover image"
+            title="Remove cover image"
+            hidden
+          >
+            <span aria-hidden="true">&times;</span>
+          </button>
         </div>
-        <div class="cover-actions">
-          <label class="button button--file" for="cover-upload">Upload from device</label>
-          <input id="cover-upload" type="file" accept="image/*" hidden />
-          <button id="cover-screenshot" class="button" type="button">Capture screenshot</button>
+        <div class="image-tools">
+          <button
+            id="toggle-detected-images"
+            class="button button--ghost"
+            type="button"
+            aria-expanded="false"
+            aria-controls="image-selection"
+          >
+            Show detected images
+          </button>
         </div>
-        <div id="image-selection" class="image-selection"></div>
+        <div id="image-selection" class="image-selection" hidden></div>
       </section>
 
       <section class="popup__section">

--- a/popup.js
+++ b/popup.js
@@ -3,7 +3,8 @@ const state = {
   coverSourceType: null,
   images: [],
   activeTabId: null,
-  activeWindowId: null
+  activeWindowId: null,
+  imageSelectionVisible: false
 };
 
 const elements = {};
@@ -11,11 +12,14 @@ const elements = {};
 function cacheElements() {
   elements.pageTitle = document.getElementById('page-title');
   elements.pageUrl = document.getElementById('page-url');
-  elements.coverPlaceholder = document.getElementById('cover-placeholder');
+  elements.coverContainer = document.getElementById('cover-container');
+  elements.coverEmpty = document.getElementById('cover-empty');
   elements.coverPreview = document.getElementById('cover-preview');
+  elements.coverRemove = document.getElementById('cover-remove');
   elements.coverUpload = document.getElementById('cover-upload');
   elements.coverScreenshot = document.getElementById('cover-screenshot');
   elements.imageSelection = document.getElementById('image-selection');
+  elements.imageSelectionToggle = document.getElementById('toggle-detected-images');
   elements.categorySelect = document.getElementById('category-select');
   elements.recommendationInput = document.getElementById('recommendation-input');
   elements.publishButton = document.getElementById('publish-button');
@@ -39,16 +43,31 @@ function setCoverImage(coverImage, sourceType) {
   state.coverImage = coverImage;
   state.coverSourceType = sourceType;
 
-  if (coverImage && coverImage.src) {
+  const hasImage = Boolean(coverImage && coverImage.src);
+
+  if (hasImage) {
     elements.coverPreview.src = coverImage.src;
     elements.coverPreview.hidden = false;
-    elements.coverPlaceholder.hidden = true;
+    elements.coverEmpty.hidden = true;
+    elements.coverRemove.hidden = false;
   } else {
     elements.coverPreview.hidden = true;
-    elements.coverPlaceholder.hidden = false;
+    elements.coverEmpty.hidden = false;
+    elements.coverRemove.hidden = true;
+    if (elements.coverUpload) {
+      elements.coverUpload.value = '';
+    }
   }
 
+  elements.coverContainer.classList.toggle('cover-container--empty', !hasImage);
+  elements.coverContainer.classList.toggle('cover-container--has-image', hasImage);
+
   updateImageSelectionHighlight();
+}
+
+function clearCoverImage() {
+  setCoverImage(null, null);
+  setStatus('Cover image removed. Please choose, upload, or capture a new image.');
 }
 
 function updateImageSelectionHighlight() {
@@ -85,8 +104,29 @@ function renderImageSelection(images) {
     emptyState.textContent = 'No images detected on this page.';
     emptyState.className = 'image-selection__empty';
     elements.imageSelection.appendChild(emptyState);
+    elements.imageSelection.hidden = true;
+    state.imageSelectionVisible = false;
+    if (elements.imageSelectionToggle) {
+      elements.imageSelectionToggle.disabled = false;
+      elements.imageSelectionToggle.textContent = 'Show detected images (0)';
+      elements.imageSelectionToggle.setAttribute('aria-expanded', 'false');
+    }
     return;
   }
+
+  if (elements.imageSelectionToggle) {
+    const countLabel = `Show detected images (${images.length})`;
+    elements.imageSelectionToggle.disabled = false;
+    elements.imageSelectionToggle.textContent = state.imageSelectionVisible
+      ? 'Hide detected images'
+      : countLabel;
+    elements.imageSelectionToggle.setAttribute(
+      'aria-expanded',
+      state.imageSelectionVisible ? 'true' : 'false'
+    );
+  }
+
+  elements.imageSelection.hidden = !state.imageSelectionVisible;
 
   images.forEach((image) => {
     const button = document.createElement('button');
@@ -109,6 +149,27 @@ function renderImageSelection(images) {
   });
 
   updateImageSelectionHighlight();
+}
+
+function toggleImageSelectionVisibility() {
+  if (!elements.imageSelectionToggle) {
+    return;
+  }
+
+  if (elements.imageSelectionToggle.disabled) {
+    return;
+  }
+
+  state.imageSelectionVisible = !state.imageSelectionVisible;
+  elements.imageSelection.hidden = !state.imageSelectionVisible;
+  const collapsedLabel = `Show detected images (${state.images.length})`;
+  elements.imageSelectionToggle.textContent = state.imageSelectionVisible
+    ? 'Hide detected images'
+    : collapsedLabel;
+  elements.imageSelectionToggle.setAttribute(
+    'aria-expanded',
+    state.imageSelectionVisible ? 'true' : 'false'
+  );
 }
 
 async function queryActiveTab() {
@@ -277,6 +338,7 @@ function handleFileUpload(event) {
   reader.onload = () => {
     setCoverImage({ src: reader.result }, 'upload');
     setStatus('Cover image updated from your upload.');
+    event.target.value = '';
   };
   reader.onerror = () => {
     setStatus('Failed to read the selected file. Please try again.', 'error');
@@ -353,11 +415,13 @@ async function initialize() {
         setStatus('No main image detected. Please choose or upload a cover.', 'error');
       }
     } else {
+      state.images = [];
       setCoverImage(null, null);
       renderImageSelection([]);
       setStatus('No images detected on this page. Please upload or capture a cover image.', 'error');
     }
   } catch (error) {
+    state.images = [];
     setCoverImage(null, null);
     renderImageSelection([]);
     setStatus(`Unable to inspect the page: ${error.message}`, 'error');
@@ -367,6 +431,8 @@ async function initialize() {
 
   elements.coverUpload.addEventListener('change', handleFileUpload);
   elements.coverScreenshot.addEventListener('click', handleScreenshotCapture);
+  elements.coverRemove.addEventListener('click', clearCoverImage);
+  elements.imageSelectionToggle.addEventListener('click', toggleImageSelectionVisibility);
   elements.publishButton.addEventListener('click', handlePublish);
 }
 


### PR DESCRIPTION
## Summary
- mark the cover container as empty by default so only placeholder controls appear initially
- add CSS rules that hide placeholder controls when an image is present and suppress the remove button otherwise
- toggle the container state classes in JavaScript alongside the existing hidden logic

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d122afedb48331b7554489339acd91